### PR TITLE
Docs: Update GSoC section to 2026

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Machine Learning for Science github site
 Machine Learning for Science (ML4Sci) is an open-source organization that brings together modern machine learning techniques and applies them to cutting edge problems in Science, Technology, Engineering, and Math (STEM). 
 
 ## ML4SCI in GSoC 2022
-The ML4Sci open source organization is participating in the [2022 Google Summer of Code](https://summerofcode.withgoogle.com/). If you are a student interested in our [projects](https://ml4sci.org/activities/gsoc.html) please check our [ideas page](https://ml4sci.org/gsoc/2022/summary.html). ML4Sci is an umbrella organization that welcomes other projects and organizations related to machine-learning for science. Please contact the admins at [ml4-sci@cern.ch](ml4-sci@cern.ch) if you are interested in participating as a project.
+The ML4Sci open source organization is participating in the [2022 Google Summer of Code](https://summerofcode.withgoogle.com/archive/2022/organizations/machine-learning-for-science-ml4sci). If you are a student interested in our [projects](https://summerofcode.withgoogle.com/archive/2022/organizations/machine-learning-for-science-ml4sci#projects-list) please check our [ideas page](https://ml4sci.org/gsoc/2022/summary.html). ML4Sci is an umbrella organization that welcomes other projects and organizations related to machine-learning for science. Please contact the admins at [ml4-sci@cern.ch](ml4-sci@cern.ch) if you are interested in participating as a project.
 ![GSOC](https://ml4sci.org/images/GSoC/GSoC-icon-192.png)
 
 Please take a look at our [GSoC Page](https://ml4sci.org/activities/gsoc.html) for more details.

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ Machine Learning for Science github site
 ## About ML4SCI
 Machine Learning for Science (ML4Sci) is an open-source organization that brings together modern machine learning techniques and applies them to cutting edge problems in Science, Technology, Engineering, and Math (STEM). 
 
-## ML4SCI in GSoC 2022
-The ML4Sci open source organization is participating in the [2022 Google Summer of Code](https://summerofcode.withgoogle.com/archive/2022/organizations/machine-learning-for-science-ml4sci). If you are a student interested in our [projects](https://ml4sci.org/activities/gsoc2022.html) please check our [ideas page](https://ml4sci.org/gsoc/2022/summary.html). ML4Sci is an umbrella organization that welcomes other projects and organizations related to machine-learning for science. Please contact the admins at [ml4-sci@cern.ch](mailto:ml4-sci@cern.ch) if you are interested in participating as a project.
+## ML4SCI in GSoC 2026
+The ML4Sci open source organization is participating in the [2026 Google Summer of Code](https://summerofcode.withgoogle.com/). If you are a student interested in our [projects](https://ml4sci.org/activities/gsoc2026.html) please check our [ideas page](https://ml4sci.org/gsoc/2026/summary.html). ML4Sci is an umbrella organization that welcomes other projects and organizations related to machine-learning for science. Please contact the admins at [ml4-sci@cern.ch](mailto:ml4-sci@cern.ch) if you are interested in participating as a project.
 ![GSOC](https://ml4sci.org/images/GSoC/GSoC-icon-192.png)
 
-Please take a look at our [GSoC Page](https://ml4sci.org/activities/gsoc2022.html) for more details.
+Please take a look at our [GSoC Page](https://ml4sci.org/activities/gsoc2026.html) for more details.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Machine Learning for Science github site
 Machine Learning for Science (ML4Sci) is an open-source organization that brings together modern machine learning techniques and applies them to cutting edge problems in Science, Technology, Engineering, and Math (STEM). 
 
 ## ML4SCI in GSoC 2022
-The ML4Sci open source organization is participating in the [2022 Google Summer of Code](https://summerofcode.withgoogle.com/archive/2022/organizations/machine-learning-for-science-ml4sci). If you are a student interested in our [projects](https://summerofcode.withgoogle.com/archive/2022/organizations/machine-learning-for-science-ml4sci#projects-list) please check our [ideas page](https://ml4sci.org/gsoc/2022/summary.html). ML4Sci is an umbrella organization that welcomes other projects and organizations related to machine-learning for science. Please contact the admins at [ml4-sci@cern.ch](mailto:ml4-sci@cern.ch) if you are interested in participating as a project.
+The ML4Sci open source organization is participating in the [2022 Google Summer of Code](https://summerofcode.withgoogle.com/archive/2022/organizations/machine-learning-for-science-ml4sci). If you are a student interested in our [projects](https://ml4sci.org/activities/gsoc2022.html) please check our [ideas page](https://ml4sci.org/gsoc/2022/summary.html). ML4Sci is an umbrella organization that welcomes other projects and organizations related to machine-learning for science. Please contact the admins at [ml4-sci@cern.ch](mailto:ml4-sci@cern.ch) if you are interested in participating as a project.
 ![GSOC](https://ml4sci.org/images/GSoC/GSoC-icon-192.png)
 
-Please take a look at our [GSoC Page](https://summerofcode.withgoogle.com/archive/2025/organizations/machine-learning-for-science-ml4sci) for more details.
+Please take a look at our [GSoC Page](https://ml4sci.org/activities/gsoc2022.html) for more details.

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Machine Learning for Science (ML4Sci) is an open-source organization that brings
 
 ## ML4SCI in GSoC 2026
 The ML4Sci open source organization is participating in the [2026 Google Summer of Code](https://summerofcode.withgoogle.com/). If you are a student interested in our [projects](https://ml4sci.org/activities/gsoc2026.html) please check our [ideas page](https://ml4sci.org/gsoc/2026/summary.html). ML4Sci is an umbrella organization that welcomes other projects and organizations related to machine-learning for science. Please contact the admins at [ml4-sci@cern.ch](mailto:ml4-sci@cern.ch) if you are interested in participating as a project.
+
 ![GSOC](https://ml4sci.org/images/GSoC/GSoC-icon-192.png)
 
 Please take a look at our [GSoC Page](https://ml4sci.org/activities/gsoc2026.html) for more details.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<img width="2041" height="1168" alt="image" src="https://github.com/user-attachments/assets/52809dd3-bf69-4c6e-bb5c-46ad2dfa15e6" /># ML4SCI.github.io
+# ML4SCI.github.io
 Machine Learning for Science github site
 
 * Live at https://ml4sci.org

--- a/README.md
+++ b/README.md
@@ -10,4 +10,4 @@ Machine Learning for Science (ML4Sci) is an open-source organization that brings
 The ML4Sci open source organization is participating in the [2022 Google Summer of Code](https://summerofcode.withgoogle.com/archive/2022/organizations/machine-learning-for-science-ml4sci). If you are a student interested in our [projects](https://summerofcode.withgoogle.com/archive/2022/organizations/machine-learning-for-science-ml4sci#projects-list) please check our [ideas page](https://ml4sci.org/gsoc/2022/summary.html). ML4Sci is an umbrella organization that welcomes other projects and organizations related to machine-learning for science. Please contact the admins at [ml4-sci@cern.ch](ml4-sci@cern.ch) if you are interested in participating as a project.
 ![GSOC](https://ml4sci.org/images/GSoC/GSoC-icon-192.png)
 
-Please take a look at our [GSoC Page](https://ml4sci.org/activities/gsoc.html) for more details.
+Please take a look at our [GSoC Page](https://summerofcode.withgoogle.com/) for more details.

--- a/README.md
+++ b/README.md
@@ -10,4 +10,4 @@ Machine Learning for Science (ML4Sci) is an open-source organization that brings
 The ML4Sci open source organization is participating in the [2022 Google Summer of Code](https://summerofcode.withgoogle.com/archive/2022/organizations/machine-learning-for-science-ml4sci). If you are a student interested in our [projects](https://summerofcode.withgoogle.com/archive/2022/organizations/machine-learning-for-science-ml4sci#projects-list) please check our [ideas page](https://ml4sci.org/gsoc/2022/summary.html). ML4Sci is an umbrella organization that welcomes other projects and organizations related to machine-learning for science. Please contact the admins at [ml4-sci@cern.ch](mailto:ml4-sci@cern.ch) if you are interested in participating as a project.
 ![GSOC](https://ml4sci.org/images/GSoC/GSoC-icon-192.png)
 
-Please take a look at our [GSoC Page](https://summerofcode.withgoogle.com/) for more details.
+Please take a look at our [GSoC Page](https://summerofcode.withgoogle.com/archive/2025/organizations/machine-learning-for-science-ml4sci) for more details.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ML4SCI.github.io
+<img width="2041" height="1168" alt="image" src="https://github.com/user-attachments/assets/52809dd3-bf69-4c6e-bb5c-46ad2dfa15e6" /># ML4SCI.github.io
 Machine Learning for Science github site
 
 * Live at https://ml4sci.org
@@ -7,7 +7,7 @@ Machine Learning for Science github site
 Machine Learning for Science (ML4Sci) is an open-source organization that brings together modern machine learning techniques and applies them to cutting edge problems in Science, Technology, Engineering, and Math (STEM). 
 
 ## ML4SCI in GSoC 2022
-The ML4Sci open source organization is participating in the [2022 Google Summer of Code](https://summerofcode.withgoogle.com/archive/2022/organizations/machine-learning-for-science-ml4sci). If you are a student interested in our [projects](https://summerofcode.withgoogle.com/archive/2022/organizations/machine-learning-for-science-ml4sci#projects-list) please check our [ideas page](https://ml4sci.org/gsoc/2022/summary.html). ML4Sci is an umbrella organization that welcomes other projects and organizations related to machine-learning for science. Please contact the admins at [ml4-sci@cern.ch](ml4-sci@cern.ch) if you are interested in participating as a project.
+The ML4Sci open source organization is participating in the [2022 Google Summer of Code](https://summerofcode.withgoogle.com/archive/2022/organizations/machine-learning-for-science-ml4sci). If you are a student interested in our [projects](https://summerofcode.withgoogle.com/archive/2022/organizations/machine-learning-for-science-ml4sci#projects-list) please check our [ideas page](https://ml4sci.org/gsoc/2022/summary.html). ML4Sci is an umbrella organization that welcomes other projects and organizations related to machine-learning for science. Please contact the admins at [ml4-sci@cern.ch](mailto:ml4-sci@cern.ch) if you are interested in participating as a project.
 ![GSOC](https://ml4sci.org/images/GSoC/GSoC-icon-192.png)
 
 Please take a look at our [GSoC Page](https://summerofcode.withgoogle.com/) for more details.


### PR DESCRIPTION
Replaced the outdated GSoC 2022 section with the current GSoC 2026 information.

**Changes:**
- Updated program year to 2026.
- Updated links to the active GSoC projects and ideas pages.
- Fixed the admin email to use the 'mailto:' format.

### Why is this needed?
New students visiting the repo were seeing outdated information and "404 Not Found" errors. This update ensures applicants for GSoC 2026 are directed to the correct resources.