### PR TITLE
Handle empty events category with a message

### DIFF
--- a/events.html
+++ b/events.html
@@ -1,20 +1,33 @@
 ---
 title: "Events"
-layout:  default
+layout: default
 ---
 
 <div class="row">
 
-{% for post in site.categories.events %}
+{% if site.categories.events.size == 0 %}
 
-<div class="blog-post">
-<h2 class="blog-post-title"><a href="{{ post.url }}">{{ post.title }}</a></h2>
-<p class="blog-post-meta">{{ post.date | date_to_string }} by <a href="{{ post.url }}">{{ post.author }}</a></p>
+  <p>No events available at the moment. Please check back later.</p>
 
-{{ post.excerpt }}
+{% else %}
 
-</div>
+  {% for post in site.categories.events %}
 
-{% endfor %}
+  <div class="blog-post">
+    <h2 class="blog-post-title">
+      <a href="{{ post.url }}">{{ post.title }}</a>
+    </h2>
+    <p class="blog-post-meta">
+      {{ post.date | date_to_string }} by 
+      <a href="{{ post.url }}">{{ post.author }}</a>
+    </p>
+
+    {{ post.excerpt }}
+
+  </div>
+
+  {% endfor %}
+
+{% endif %}
 
 </div>


### PR DESCRIPTION
Description

This PR adds a conditional check to display a message when there are no posts in the events category.

Previously, the page would appear empty if no events were available.
Now it shows a user-friendly message to improve the user experience.