### PR TITLE
Add system architecture section to AutoEIT project description

### DIFF
--- a/_gsocprojects/2026/project_AutoEIT.md
+++ b/_gsocprojects/2026/project_AutoEIT.md
@@ -8,3 +8,6 @@ description: |
 ---
 
 {% include gsoc_project.ext %}
+### System Architecture
+
+The AutoEIT system can follow a pipeline where learner audio recordings are first preprocessed to remove noise and segment the speech. The processed audio is then passed through a speech-to-text model to generate a transcription. The transcription can later be evaluated using similarity metrics to assess the learner’s response accuracy.


### PR DESCRIPTION
This PR adds a small "System Architecture" section to the AutoEIT project page.

The section briefly explains the possible pipeline for processing learner audio:
audio preprocessing → speech-to-text transcription → transcription evaluation.

This clarification may help contributors better understand the intended workflow of the AutoEIT system.