### PR TITLE
docs: fix typo in project_TableTalk.md

### DIFF
--- a/_gsocprojects/2026/project_TableTalk.md
+++ b/_gsocprojects/2026/project_TableTalk.md
@@ -4,7 +4,7 @@ layout: default
 logo: TableTalk.png
 description: |
   Tabletop role-playing games and narrative board games rely heavily on storytelling, atmosphere, and narration to create immersive player experiences. In many games, the person leading the story must deliver long passages of descriptive text, control pacing, and establish emotional tone while guiding players through unfolding narrative events. Although digital tools exist to assist with gameplay mechanics, very few systems integrate recorded voice performance, narrative scripting, and environmental effects into a uniﬁed storytelling platform. As a result, most tabletop narration remains dependent on a single human storyteller rather than a system that can dynamically support narrative delivery and atmosphere.
-  u
+  
   The TableTalk project aims to develop a system that allows recorded narrative voice performances to be triggered dynamically during gameplay while coordinating atmospheric effects such as sound, lighting, or other environmental cues. The system consists of a mobile application that stores and organizes narrative voice recordings paired with a tabletop device capable of producing immersive sensory feedback corresponding with story events. Together these components form a narrative artifact that enhances tabletop storytelling by coordinating narration and environmental responses within a shared interactive experience.
 ---
 


### PR DESCRIPTION
Removed a stray 'u' character on line 7 and corrected paragraph spacing from the project description.