### PR TITLE
Add GSoC 2026 section to student blogs

### DIFF
--- a/_activities/studentblogs.md
+++ b/_activities/studentblogs.md
@@ -13,6 +13,13 @@ layout: default
 
 This is a collection of blog posts from GSoC students who worked with HumanAI.
 
+### Google Summer of Code 2026
+
+<table class="table table-hover table-striped">
+  <tr>
+    <td><a href="https://medium.com/@vennelavarshini07/micro-rooms-macro-noise-engineering-the-tcamp-architecture-for-human-factors-research-380235fc242b" target="_blank">"TCAMP: Automated Team Communication Analysis Pipeline for Human-Factors Research" by Vennela Varshini Anasoori</a></td>
+  </tr>
+</table>
 ### Google Summer of Code 2025
 
 <table class="table table-hover table-striped">
@@ -78,4 +85,5 @@ This is a collection of blog posts from GSoC students who worked with HumanAI.
 ## Contacts
 
 *HumanAI GSoC Admins* [human-ai@cern.ch](mailto:human-ai@cern.ch)
+
 


### PR DESCRIPTION
Added a new section for Google Summer of Code 2026 with Vennela's blog post link for the TCAMP project.